### PR TITLE
Fix model downloading problem which caused the tensor miss-match problem

### DIFF
--- a/yolov5/utils/downloads.py
+++ b/yolov5/utils/downloads.py
@@ -55,16 +55,17 @@ def attempt_download(file, repo='ultralytics/yolov5'):  # from utils.downloads i
         # GitHub assets
         file.parent.mkdir(parents=True, exist_ok=True)  # make parent dir (if required)
         try:
-            response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
-            assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
-            tag = response['tag_name']  # i.e. 'v1.0'
-        except:  # fallback plan
             assets = ['yolov5s.pt', 'yolov5m.pt', 'yolov5l.pt', 'yolov5x.pt',
                       'yolov5s6.pt', 'yolov5m6.pt', 'yolov5l6.pt', 'yolov5x6.pt']
             try:
                 tag = subprocess.check_output('git tag', shell=True, stderr=subprocess.STDOUT).decode().split()[-1]
             except:
                 tag = 'v5.0'  # current release
+                
+        except:  # fallback plan
+            response = requests.get(f'https://api.github.com/repos/{repo}/releases/latest').json()  # github api
+            assets = [x['name'] for x in response['assets']]  # release assets, i.e. ['yolov5s.pt', 'yolov5m.pt', ...]
+            tag = response['tag_name']  # i.e. 'v1.0'
 
         if name in assets:
             safe_download(file,


### PR DESCRIPTION
`RuntimeError: The size of tensor a (80) must match the size of tensor b (56) at non-singleton dimension 3`

This problem is caused due to downloading the older version of the models, which did not support dynamic image size. Downloading the latest models solves the problem. Making this change downloads and seamlessly runs the tracker.